### PR TITLE
Feat: home if View adj

### DIFF
--- a/DolHaruBang/DolHaruBang/Pages/Home/Modules/Profile/Source/Core/ProfileFeature.swift
+++ b/DolHaruBang/DolHaruBang/Pages/Home/Modules/Profile/Source/Core/ProfileFeature.swift
@@ -15,7 +15,6 @@ struct ProfileFeature {
     struct State: Equatable {
         @Shared(.inMemory("dolprofile")) var captureDol: UIImage = UIImage() // 돌머리
         var profile : ProfileInfo?
-        
         var isLoading : Bool = false
         var selectedProfileEdit : Bool = false
         var dolName = ""

--- a/DolHaruBang/DolHaruBang/Pages/Home/Modules/Profile/Source/View/ProfileView.swift
+++ b/DolHaruBang/DolHaruBang/Pages/Home/Modules/Profile/Source/View/ProfileView.swift
@@ -136,8 +136,7 @@ struct ProfileView: View {
                     .padding(.top, 20)
                     
                     Divider()
-                        .frame(width: 272)
-                        .foregroundColor(Color.init(hex: "E5DFD7"))
+                        .frame(width: 272).background(Color(hex: "E5DFD7"))
                     
                     // 활성능력탭
                     VStack(spacing: 8) {
@@ -174,8 +173,7 @@ struct ProfileView: View {
                     .padding(.vertical, 6)
                     
                     Divider()
-                        .frame(width: 272)
-                        .background(Color(red: 0.90, green: 0.87, blue: 0.84))
+                        .frame(width: 272).background(Color(hex: "E5DFD7"))
                     
                     // 잠재능력탭
                     VStack(alignment: .leading,spacing: 8) {

--- a/DolHaruBang/DolHaruBang/Pages/Home/Source/Views/HomeView.swift
+++ b/DolHaruBang/DolHaruBang/Pages/Home/Source/Views/HomeView.swift
@@ -239,84 +239,7 @@ struct HomeView : View {
                         .position(x: 110, y: 210)
                 }
                 
-                // MARK: 공유버튼
-                if store.shareButton {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            store.send(.closeShare)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .zIndex(1)
-                    ShareView(
-                        showPopup: $store.shareButton, DolImage: $store.captureDol
-                    )
-                    .background(Color.white)
-                    .cornerRadius(25)
-                    .shadow(radius: 10)
-                    .zIndex(2)
-                }
-                
-                // MARK: 펫말
-                if store.sign {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            store.send(.closeSign)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .zIndex(1)
-                    SignView(
-                        showPopup: $store.sign,
-                        initMessage: $store.signText, store: Store(initialState: SignFeature.State()){
-                            SignFeature()}
-                    )
-                    .background(Color.white)
-                    .cornerRadius(25)
-                    .shadow(radius: 10)
-                    .zIndex(2)
-                }
-                
-                // MARK: 프로필
-                if store.profile {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            store.send(.closeProfile)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .zIndex(1)
-                    ProfileView(
-                        showPopup: $store.profile, store: Store(initialState: ProfileFeature.State()){
-                            ProfileFeature()
-                        }
-                    )
-                    .background(Color.white)
-                    .cornerRadius(25)
-                    .shadow(radius: 10)
-                    .zIndex(2)
-                }
-                
-                // MARK: 우체통
-                if store.mail {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            store.send(.closeMail)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .zIndex(1)
-                    MailView(
-                        showPopup: $store.mail, store: Store(initialState: MailFeature.State()){
-                            MailFeature()
-                        }
-                    )
-                    .background(Color.white)
-                    .cornerRadius(25)
-                    .shadow(radius: 10)
-                    .zIndex(2)
-                }
-                
+                // MARK: 돌이름, 편지갯수, 친밀도
                 if let basicInfo = store.basicInfo {
                     ZStack(alignment: .center){
                         Image("Vector").resizable().scaledToFit()
@@ -366,6 +289,86 @@ struct HomeView : View {
                         )
                         
                 }
+                
+                // MARK: 공유버튼
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            store.send(.closeShare)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .zIndex(1)
+                    ShareView(
+                        showPopup: $store.shareButton, DolImage: $store.captureDol
+                    )
+                    .background(Color.white)
+                    .cornerRadius(25)
+                    .shadow(radius: 10)
+                    .zIndex(2)
+                }.opacity(store.shareButton ? 1 : 0)
+                
+                // MARK: 펫말
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            store.send(.closeSign)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .zIndex(1)
+                    SignView(
+                        showPopup: $store.sign,
+                        initMessage: $store.signText, store: Store(initialState: SignFeature.State()){
+                            SignFeature()}
+                    )
+                    .background(Color.white)
+                    .cornerRadius(25)
+                    .shadow(radius: 10)
+                    .zIndex(2)
+                }.opacity(store.sign ? 1 : 0)
+                
+                // MARK: 프로필
+                ZStack{
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            store.send(.closeProfile)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .zIndex(1)
+                    ProfileView(
+                        showPopup: $store.profile, store: Store(initialState: ProfileFeature.State()){
+                            ProfileFeature()
+                        }
+                    )
+                    .background(Color.white)
+                    .cornerRadius(25)
+                    .shadow(radius: 10)
+                    .zIndex(2)
+                }.opacity(store.profile ? 1 : 0)
+                
+                // MARK: 우체통
+                ZStack{
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            store.send(.closeMail)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .zIndex(1)
+                    MailView(
+                        showPopup: $store.mail, store: Store(initialState: MailFeature.State()){
+                            MailFeature()
+                        }
+                    )
+                    .background(Color.white)
+                    .cornerRadius(25)
+                    .shadow(radius: 10)
+                    .zIndex(2)
+                }.opacity(store.mail ? 1 : 0)
+                
+                
                 
             } // ZStack
             .edgesIgnoringSafeArea(.all)


### PR DESCRIPTION
돌프로필의 경우 불러올때 새로 불러오는동안 정보가 사라져서, 캐시 최적화가 안되어있다고 생각했지만, 그게 아니라
돌프로필뷰의 경우 if문을 통해 보여줄지 말지 정하는데 이렇게 만들면 뷰를 새로 그릴때 그전에 불러온 상태가 완전히 소멸되어 캐싱되지않는다.
그래서 opacity로 설정해 해결