### PR TITLE
[be/feat/mission] 친구 관련 미션 이벤트 처리

### DIFF
--- a/dolharubang/src/main/java/com/dolharubang/domain/event/FriendEvent.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/event/FriendEvent.java
@@ -1,0 +1,8 @@
+package com.dolharubang.domain.event;
+
+import com.dolharubang.type.FriendActionType;
+import java.time.LocalDate;
+
+public record FriendEvent(Long memberId, FriendActionType actionType, LocalDate date) {
+
+}

--- a/dolharubang/src/main/java/com/dolharubang/repository/MemberMissionRepository.java
+++ b/dolharubang/src/main/java/com/dolharubang/repository/MemberMissionRepository.java
@@ -4,6 +4,7 @@ import com.dolharubang.domain.entity.Member;
 import com.dolharubang.domain.entity.MemberMission;
 import com.dolharubang.domain.entity.Mission;
 import com.dolharubang.type.MissionCategory;
+import com.dolharubang.type.MissionStatusType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,6 +22,6 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
 
     void deleteAllByMember(Member member);
 
-    List<MemberMission> findByMemberAndMission_Condition_Category(Member member,
-        MissionCategory category);
+    List<MemberMission> findByMemberAndMission_Condition_CategoryAndStatusNot(Member member,
+        MissionCategory category, MissionStatusType status);
 }

--- a/dolharubang/src/main/java/com/dolharubang/service/handler/AttendanceMissionHandler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/handler/AttendanceMissionHandler.java
@@ -34,9 +34,10 @@ public class AttendanceMissionHandler {
         Member member = memberRepository.findById(event.memberId())
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_Condition_Category(
+        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_Condition_CategoryAndStatusNot(
             member,
-            MissionCategory.ATTENDANCE
+            MissionCategory.ATTENDANCE,
+            MissionStatusType.COMPLETED
         );
 
         missions.forEach(mission -> {

--- a/dolharubang/src/main/java/com/dolharubang/service/handler/DiaryMissionHandler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/handler/DiaryMissionHandler.java
@@ -34,8 +34,8 @@ public class DiaryMissionHandler {
         Member member = memberRepository.findById(event.memberId())
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_Condition_Category(
-            member, MissionCategory.DIARY
+        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_Condition_CategoryAndStatusNot(
+            member, MissionCategory.DIARY, MissionStatusType.COMPLETED
         );
 
         missions.forEach(mission -> {
@@ -62,7 +62,7 @@ public class DiaryMissionHandler {
         progressInfo.setLastUpdateDate(eventDate.atStartOfDay());
         mission.setProgress(diaryCount >= 1 ? 1.0 : 0.0);
     }
-    
+
     private void handleContinuous(MemberMission mission, MissionProgressInfo progressInfo,
         LocalDate eventDate) {
         LocalDate lastDate = progressInfo.getLastUpdateDate() != null

--- a/dolharubang/src/main/java/com/dolharubang/service/handler/FriendMissionHandler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/handler/FriendMissionHandler.java
@@ -1,0 +1,99 @@
+package com.dolharubang.service.handler;
+
+import com.dolharubang.domain.entity.Member;
+import com.dolharubang.domain.entity.MemberMission;
+import com.dolharubang.domain.entity.MissionCondition;
+import com.dolharubang.domain.entity.MissionProgressInfo;
+import com.dolharubang.domain.event.FriendEvent;
+import com.dolharubang.exception.CustomException;
+import com.dolharubang.exception.ErrorCode;
+import com.dolharubang.repository.MemberMissionRepository;
+import com.dolharubang.repository.MemberRepository;
+import com.dolharubang.type.MissionCategory;
+import com.dolharubang.type.MissionStatusType;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FriendMissionHandler {
+
+    private final MemberMissionRepository memberMissionRepository;
+    private final MemberRepository memberRepository;
+
+    @EventListener
+    @Transactional
+    public void handleFriend(FriendEvent event) {
+        Member member = memberRepository.findById(event.memberId())
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_Condition_CategoryAndStatusNot(
+            member, MissionCategory.FRIEND, MissionStatusType.COMPLETED
+        );
+
+        missions.forEach(mission -> {
+            MissionCondition condition = mission.getMission().getCondition();
+            MissionProgressInfo progressInfo = mission.getProgressInfo();
+            String requiredAction = (String) condition.getDetails().get("actionType");
+
+            // 미션의 actionType과 이벤트의 actionType이 일치할 때만 진행
+            if (event.actionType().name().equalsIgnoreCase(requiredAction)) {
+                switch (condition.getConditionType()) {
+                    case FIRST -> handleFirst(progressInfo, mission);
+                    case CUMULATIVE ->
+                        handleCumulative(progressInfo, mission, condition.getRequiredValue());
+                    case CONTINUOUS -> handleContinuous(progressInfo, mission, event.date(),
+                        condition.getRequiredValue());
+                }
+                updateMissionStatus(mission);
+                memberMissionRepository.save(mission);
+            }
+        });
+    }
+
+    private void handleFirst(MissionProgressInfo progressInfo, MemberMission mission) {
+        if (progressInfo.getCurrentValue() < 1) {
+            progressInfo.setCurrentValue(1);
+            mission.setProgress(1.0);
+        }
+    }
+
+    private void handleCumulative(MissionProgressInfo progressInfo, MemberMission mission,
+        int requiredValue) {
+        int count = progressInfo.getTotalCount();
+        progressInfo.setTotalCount(count + 1);
+        mission.setProgress(Math.min(1.0, (double) progressInfo.getTotalCount() / requiredValue));
+    }
+
+    private void handleContinuous(MissionProgressInfo progressInfo, MemberMission mission,
+        LocalDate eventDate, int requiredValue) {
+        LocalDate lastDate = progressInfo.getLastUpdateDate() != null
+            ? progressInfo.getLastUpdateDate().toLocalDate()
+            : null;
+
+        if (lastDate == null) {
+            progressInfo.setStreakCount(1);
+        } else if (lastDate.plusDays(1).equals(eventDate)) {
+            progressInfo.setStreakCount(progressInfo.getStreakCount() + 1);
+        } else {
+            progressInfo.setStreakCount(1);
+        }
+
+        progressInfo.setLastUpdateDate(eventDate.atStartOfDay());
+        mission.setProgress(Math.min(1.0, (double) progressInfo.getStreakCount() / requiredValue));
+    }
+
+    private void updateMissionStatus(MemberMission mission) {
+        if (mission.getProgress() >= 1.0 && mission.getStatus() != MissionStatusType.COMPLETED) {
+            mission.setStatus(MissionStatusType.COMPLETED);
+            mission.setAchievementDate(LocalDateTime.now());
+        } else if (mission.getProgress() > 0) {
+            mission.setStatus(MissionStatusType.PROGRESSING);
+        }
+    }
+}

--- a/dolharubang/src/main/java/com/dolharubang/type/FriendActionType.java
+++ b/dolharubang/src/main/java/com/dolharubang/type/FriendActionType.java
@@ -1,0 +1,7 @@
+package com.dolharubang.type;
+
+public enum FriendActionType {
+    ADD,      // 친구 추가
+    REJECT,   // 친구 요청 거절
+    REMOVE    // 친구 삭제
+}

--- a/dolharubang/src/main/java/com/dolharubang/type/FriendActionType.java
+++ b/dolharubang/src/main/java/com/dolharubang/type/FriendActionType.java
@@ -3,5 +3,7 @@ package com.dolharubang.type;
 public enum FriendActionType {
     ADD,      // 친구 추가
     REJECT,   // 친구 요청 거절
-    REMOVE    // 친구 삭제
+    REMOVE,    // 친구 삭제
+    SEND_REQUEST,   // 친구 요청 보내기
+    RECEIVE_REQUEST // 친구 요청 받기
 }


### PR DESCRIPTION
- 해당 카테고리에 맞는 멤버 미션 불러오는 부분 완료되지 않은 미션만 불러오도록 수정
- 친구 관련 이벤트 타입 설정 (친구 추가, 친구요청 거절, 친구 삭제, 친구 요청 보내기, 친구 요청 받기)
- 친구 관련 이벤트 레코드 생성
- 친구 관련 이벤트 핸들러 구현