### PR TITLE
[be/feat/mission] 기념일 관련 미션 처리 로직 구현

### DIFF
--- a/dolharubang/src/main/java/com/dolharubang/domain/dto/response/MemberMissionResDto.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/dto/response/MemberMissionResDto.java
@@ -44,7 +44,7 @@ public class MemberMissionResDto {
             .isRewarded(memberMission.isRewarded())
             .rewardedAt(memberMission.getRewardedAt())
             // 미션 정보
-            .missionName(mission.getName())
+            .missionName(memberMission.getDisplayName())
             .missionDescription(mission.getDescription())
             // 보상 정보
             .rewardQuantity(mission.getReward().getQuantity())

--- a/dolharubang/src/main/java/com/dolharubang/domain/dto/response/stone/StoneProfileResDto.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/dto/response/stone/StoneProfileResDto.java
@@ -5,6 +5,7 @@ import com.dolharubang.domain.entity.Species;
 import com.dolharubang.domain.entity.Stone;
 import com.dolharubang.type.AbilityType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,13 +34,14 @@ public class StoneProfileResDto {
     private List<AbilityType> potentialAbilities;
     @JsonProperty("roomName")
     private String spaceName;
+    private LocalDate adoptionDate;
 
     public static StoneProfileResDto fromEntity(Stone stone, Species species, Member member) {
         List<AbilityType> activeAbilities = new ArrayList<>();
         List<AbilityType> potentialAbilities = new ArrayList<>();
 
         stone.getAbilityAble().forEach((ability, value) -> {
-            if(ability != species.getBaseAbility()) {
+            if (ability != species.getBaseAbility()) {
                 if (value) {
                     activeAbilities.add(species.getBaseAbility());
                     activeAbilities.add(ability);
@@ -58,6 +60,7 @@ public class StoneProfileResDto {
             .activeAbilities(activeAbilities)
             .potentialAbilities(potentialAbilities)
             .spaceName(member.getSpaceName())
+            .adoptionDate(stone.getAdoptionDate())
             .build();
     }
 }

--- a/dolharubang/src/main/java/com/dolharubang/domain/entity/MemberMission.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/entity/MemberMission.java
@@ -41,6 +41,13 @@ public class MemberMission extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Mission mission;
 
+    private String customName;
+
+    @ManyToOne
+    @JoinColumn(name = "stone_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Stone stone; // 입양/기념일 미션만 값이 있음, 나머지는 null
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MissionStatusType status;
@@ -57,9 +64,11 @@ public class MemberMission extends BaseEntity {
     private LocalDateTime rewardedAt;
 
     @Builder
-    public MemberMission(Member member, Mission mission) {
+    public MemberMission(Member member, Mission mission, Stone stone, String customName) {
         this.member = member;
         this.mission = mission;
+        this.customName = customName;
+        this.stone = stone;
         this.status = MissionStatusType.NOT_STARTED;
         this.progress = 0.0;
         this.isRewarded = false;
@@ -141,5 +150,12 @@ public class MemberMission extends BaseEntity {
 
     public void setAchievementDate(LocalDateTime achievementDate) {
         this.achievementDate = achievementDate;
+    }
+
+    // customName이 있으면 customName, 없으면 mission.name 반환
+    public String getDisplayName() {
+        return this.customName != null
+            ? this.customName
+            : this.getMission().getName();
     }
 }

--- a/dolharubang/src/main/java/com/dolharubang/domain/entity/MissionProgressInfo.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/entity/MissionProgressInfo.java
@@ -3,14 +3,13 @@ package com.dolharubang.domain.entity;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor()
 public class MissionProgressInfo {
 
     private int currentValue;

--- a/dolharubang/src/main/java/com/dolharubang/domain/entity/Stone.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/entity/Stone.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyEnumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.Builder;
@@ -46,15 +47,18 @@ public class Stone extends BaseEntity {
     private Map<AbilityType, Boolean> abilityAble;
 
     private String signText;
+    private LocalDate adoptionDate;
 
     @Builder
-    public Stone (Member member, Long speciesId, String stoneName, Long closeness, Map<AbilityType, Boolean> abilityAble, String signText) {
+    public Stone(Member member, Long speciesId, String stoneName, Long closeness,
+        Map<AbilityType, Boolean> abilityAble, String signText, LocalDate adoptionDate) {
         this.member = member;
         this.speciesId = speciesId;
         this.stoneName = stoneName;
         this.closeness = closeness;
         this.abilityAble = abilityAble;
         this.signText = signText;
+        this.adoptionDate = adoptionDate;
     }
 
     //엔티티가 영속성 컨텍스트에 저장되기 전에 호출
@@ -70,7 +74,8 @@ public class Stone extends BaseEntity {
         this.modifiedAt = LocalDateTime.now();
     }
 
-    public void update(Member member, Long speciesId, String stoneName, Long closeness, Map<AbilityType, Boolean> abilityAble, String signText) {
+    public void update(Member member, Long speciesId, String stoneName, Long closeness,
+        Map<AbilityType, Boolean> abilityAble, String signText) {
         this.member = member;
         this.speciesId = speciesId;
         this.stoneName = stoneName;

--- a/dolharubang/src/main/java/com/dolharubang/domain/event/AnniversaryEvent.java
+++ b/dolharubang/src/main/java/com/dolharubang/domain/event/AnniversaryEvent.java
@@ -1,0 +1,13 @@
+package com.dolharubang.domain.event;
+
+import java.time.LocalDate;
+
+public record AnniversaryEvent(
+    Long stoneId,
+    Long memberId,
+    LocalDate today,
+    long daysSinceAdoption
+) {
+
+}
+

--- a/dolharubang/src/main/java/com/dolharubang/repository/MissionRepository.java
+++ b/dolharubang/src/main/java/com/dolharubang/repository/MissionRepository.java
@@ -2,6 +2,7 @@ package com.dolharubang.repository;
 
 import com.dolharubang.domain.entity.Member;
 import com.dolharubang.domain.entity.Mission;
+import com.dolharubang.domain.entity.Stone;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,13 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     List<Mission> findMissionsNotAssignedToMember(@Param("member") Member member);
 
     List<Mission> findByIsDaily(boolean isDaily);
+
+    @Query(
+        "SELECT m FROM Mission m WHERE m.condition.category = 'ANNIVERSARY' AND m.deletedAt IS NULL "
+            + "AND m.id NOT IN (SELECT mm.mission.id FROM MemberMission mm "
+            + "WHERE mm.member = :member AND mm.stone = :stone)")
+    List<Mission> findUnassignedAnniversaryMissions(@Param("member") Member member,
+        @Param("stone") Stone stone);
+
+
 }

--- a/dolharubang/src/main/java/com/dolharubang/repository/StoneRepository.java
+++ b/dolharubang/src/main/java/com/dolharubang/repository/StoneRepository.java
@@ -16,5 +16,5 @@ public interface StoneRepository extends JpaRepository<Stone, Long> {
 
     void deleteAllByMember(Member member);
 
-    List<Stone> findAllByAdoptionDateIsNotNullAndIsDeletedIsNull();
+    List<Stone> findAllByAdoptionDateIsNotNullAndDeletedAtIsNull();
 }

--- a/dolharubang/src/main/java/com/dolharubang/repository/StoneRepository.java
+++ b/dolharubang/src/main/java/com/dolharubang/repository/StoneRepository.java
@@ -2,15 +2,19 @@ package com.dolharubang.repository;
 
 import com.dolharubang.domain.entity.Member;
 import com.dolharubang.domain.entity.Stone;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface StoneRepository extends JpaRepository<Stone, Long> {
+
     Optional<Stone> findByMember(Member member);
 
     @Query("SELECT s.signText FROM Stone s WHERE s.member = :member")
     String findSignTextByMember(Member member);
 
     void deleteAllByMember(Member member);
+
+    List<Stone> findAllByAdoptionDateIsNotNullAndIsDeletedIsNull();
 }

--- a/dolharubang/src/main/java/com/dolharubang/service/StoneService.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/StoneService.java
@@ -5,16 +5,21 @@ import com.dolharubang.domain.dto.request.StoneTextUpdateReqDto;
 import com.dolharubang.domain.dto.response.stone.StoneHomeResDto;
 import com.dolharubang.domain.dto.response.stone.StoneProfileResDto;
 import com.dolharubang.domain.entity.Member;
+import com.dolharubang.domain.entity.MemberMission;
+import com.dolharubang.domain.entity.Mission;
 import com.dolharubang.domain.entity.Species;
 import com.dolharubang.domain.entity.Stone;
 import com.dolharubang.exception.CustomException;
 import com.dolharubang.exception.ErrorCode;
+import com.dolharubang.repository.MemberMissionRepository;
 import com.dolharubang.repository.MemberRepository;
+import com.dolharubang.repository.MissionRepository;
 import com.dolharubang.repository.SpeciesRepository;
 import com.dolharubang.repository.StoneRepository;
 import com.dolharubang.type.AbilityType;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -29,13 +34,18 @@ public class StoneService {
     private final MemberRepository memberRepository;
     private final SpeciesRepository speciesRepository;
     private final MemberItemService memberItemService;
+    private final MissionRepository missionRepository;
+    private final MemberMissionRepository memberMissionRepository;
 
     public StoneService(StoneRepository stoneRepository, MemberRepository memberRepository,
-        SpeciesRepository speciesRepository, MemberItemService memberItemService) {
+        SpeciesRepository speciesRepository, MemberItemService memberItemService,
+        MissionRepository missionRepository, MemberMissionRepository memberMissionRepository) {
         this.stoneRepository = stoneRepository;
         this.memberRepository = memberRepository;
         this.speciesRepository = speciesRepository;
         this.memberItemService = memberItemService;
+        this.missionRepository = missionRepository;
+        this.memberMissionRepository = memberMissionRepository;
     }
 
     @Transactional
@@ -69,6 +79,10 @@ public class StoneService {
         memberRepository.save(member);
 
         Stone adoptedStone = stoneRepository.save(stone);
+
+        // 돌 입양 시 기념일 미션 부여
+        assignAnniversaryMissions(member, stone);
+
         if (adoptedStone != null) {
             return true;
         }
@@ -148,4 +162,24 @@ public class StoneService {
         return stoneRepository.findByMember(member)
             .orElseThrow(() -> new CustomException(ErrorCode.STONE_NOT_FOUND));
     }
+
+    private void assignAnniversaryMissions(Member member, Stone stone) {
+        List<Mission> unassignedMissions = missionRepository
+            .findUnassignedAnniversaryMissions(member, stone);
+
+        List<MemberMission> newMissions = unassignedMissions.stream()
+            .map(mission -> {
+                String customName = mission.getName().replace("{stoneName}", stone.getStoneName());
+                return MemberMission.builder()
+                    .member(member)
+                    .stone(stone)
+                    .mission(mission)
+                    .customName(customName)
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        memberMissionRepository.saveAll(newMissions);
+    }
+
 }

--- a/dolharubang/src/main/java/com/dolharubang/service/StoneService.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/StoneService.java
@@ -13,6 +13,7 @@ import com.dolharubang.repository.MemberRepository;
 import com.dolharubang.repository.SpeciesRepository;
 import com.dolharubang.repository.StoneRepository;
 import com.dolharubang.type.AbilityType;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -59,6 +60,7 @@ public class StoneService {
             .closeness(0L)
             .abilityAble(abilityMap)
             .signText("")
+            .adoptionDate(LocalDate.now())
             .build();
 
         member.updateSpaceName(stoneReqDto.getSpaceName());

--- a/dolharubang/src/main/java/com/dolharubang/service/handler/AnniversaryMissionHandler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/handler/AnniversaryMissionHandler.java
@@ -13,11 +13,15 @@ import com.dolharubang.type.MissionCategory;
 import com.dolharubang.type.MissionStatusType;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AnniversaryMissionHandler {
@@ -28,36 +32,60 @@ public class AnniversaryMissionHandler {
     @EventListener
     @Transactional
     public void handleAnniversary(AnniversaryEvent event) {
-        Member member = memberRepository.findById(event.memberId())
-            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        log.info("[AnniversaryMissionHandler] 이벤트 처리 시작. 회원 ID: {}, 입양일로부터 경과일: {}일",
+            event.memberId(), event.daysSinceAdoption());
 
-        List<MemberMission> missions = memberMissionRepository
-            .findByMemberAndMission_Condition_CategoryAndStatusNot(
-                member,
-                MissionCategory.ANNIVERSARY,
-                MissionStatusType.COMPLETED
-            );
+        try {
+            Member member = memberRepository.findById(event.memberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        missions.forEach(mission -> {
-            MissionCondition condition = mission.getMission().getCondition();
-            Integer requiredDays = (Integer) condition.getDetails().get("days");
+            // 완료되지 않은 ANNIVERSARY 미션 전체 조회
+            List<MemberMission> missions = memberMissionRepository
+                .findByMemberAndMission_Condition_CategoryAndStatusNot(
+                    member,
+                    MissionCategory.ANNIVERSARY,
+                    MissionStatusType.COMPLETED
+                );
+            log.info("완료되지 않은 ANNIVERSARY 미션 {}건 조회", missions.size());
 
-            if (requiredDays != null && event.daysSinceAdoption() == requiredDays) {
-                MissionProgressInfo progressInfo = mission.getProgressInfo();
-                progressInfo.setCurrentValue(1);
-                mission.setProgress(1.0);
-                updateMissionStatus(mission);
-                memberMissionRepository.save(mission);
+            // 가장 작은 anniversaryDay 값을 가진 미션 찾기
+            Optional<MemberMission> maxMissionOpt = missions.stream()
+                .filter(mission ->
+                    mission.getMission().getCondition().getDetails().get("anniversaryDay") != null
+                )
+                .min(Comparator.comparing(mission ->
+                    (Integer) mission.getMission().getCondition().getDetails().get("anniversaryDay")
+                ));
+
+            if (maxMissionOpt.isPresent()) {
+                MemberMission mission = maxMissionOpt.get();
+                MissionCondition condition = mission.getMission().getCondition();
+                Integer requiredDays = (Integer) condition.getDetails().get("anniversaryDay");
+                log.info("가장 작은 anniversaryDay({}) 미션 선택: 미션 ID={}, 상태={}",
+                    requiredDays, mission.getId(), mission.getStatus());
+
+                // 미완료 미션 처리 로직
+                if (requiredDays != null && event.daysSinceAdoption() == requiredDays) {
+                    log.info("미션 완료 조건 충족! (입양일로부터 {}일)", requiredDays);
+                    MissionProgressInfo progressInfo = mission.getProgressInfo();
+                    progressInfo.setCurrentValue(requiredDays);
+                    mission.setProgress(1.0);
+                    mission.setStatus(MissionStatusType.COMPLETED);
+                    mission.setAchievementDate(LocalDateTime.now());
+                    memberMissionRepository.save(mission);
+                    log.info("미션 완료 처리: 미션 ID={}", mission.getId());
+                } else {
+                    log.info("미션 완료 조건 불충족: 현재 경과일={}, 필요일={}",
+                        event.daysSinceAdoption(), requiredDays);
+                }
+            } else {
+                log.info("처리 가능한 미션 없음");
             }
-        });
-    }
-
-    private void updateMissionStatus(MemberMission mission) {
-        if (mission.getProgress() >= 1.0 && mission.getStatus() != MissionStatusType.COMPLETED) {
-            mission.setStatus(MissionStatusType.COMPLETED);
-            mission.setAchievementDate(LocalDateTime.now());
-        } else if (mission.getProgress() > 0) {
-            mission.setStatus(MissionStatusType.PROGRESSING);
+        } catch (Exception e) {
+            log.error("주년 미션 처리 중 오류 발생", e);
+            throw e;
+        } finally {
+            log.info("[AnniversaryMissionHandler] 이벤트 처리 완료");
         }
     }
 }

--- a/dolharubang/src/main/java/com/dolharubang/service/handler/AnniversaryMissionHandler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/handler/AnniversaryMissionHandler.java
@@ -1,0 +1,63 @@
+package com.dolharubang.service.handler;
+
+import com.dolharubang.domain.entity.Member;
+import com.dolharubang.domain.entity.MemberMission;
+import com.dolharubang.domain.entity.MissionCondition;
+import com.dolharubang.domain.entity.MissionProgressInfo;
+import com.dolharubang.domain.event.AnniversaryEvent;
+import com.dolharubang.exception.CustomException;
+import com.dolharubang.exception.ErrorCode;
+import com.dolharubang.repository.MemberMissionRepository;
+import com.dolharubang.repository.MemberRepository;
+import com.dolharubang.type.MissionCategory;
+import com.dolharubang.type.MissionStatusType;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnniversaryMissionHandler {
+
+    private final MemberMissionRepository memberMissionRepository;
+    private final MemberRepository memberRepository;
+
+    @EventListener
+    @Transactional
+    public void handleAnniversary(AnniversaryEvent event) {
+        Member member = memberRepository.findById(event.memberId())
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberMission> missions = memberMissionRepository
+            .findByMemberAndMission_Condition_CategoryAndStatusNot(
+                member,
+                MissionCategory.ANNIVERSARY,
+                MissionStatusType.COMPLETED
+            );
+
+        missions.forEach(mission -> {
+            MissionCondition condition = mission.getMission().getCondition();
+            Integer requiredDays = (Integer) condition.getDetails().get("days");
+
+            if (requiredDays != null && event.daysSinceAdoption() == requiredDays) {
+                MissionProgressInfo progressInfo = mission.getProgressInfo();
+                progressInfo.setCurrentValue(1);
+                mission.setProgress(1.0);
+                updateMissionStatus(mission);
+                memberMissionRepository.save(mission);
+            }
+        });
+    }
+
+    private void updateMissionStatus(MemberMission mission) {
+        if (mission.getProgress() >= 1.0 && mission.getStatus() != MissionStatusType.COMPLETED) {
+            mission.setStatus(MissionStatusType.COMPLETED);
+            mission.setAchievementDate(LocalDateTime.now());
+        } else if (mission.getProgress() > 0) {
+            mission.setStatus(MissionStatusType.PROGRESSING);
+        }
+    }
+}

--- a/dolharubang/src/main/java/com/dolharubang/service/scheduler/AnniversaryScheduler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/scheduler/AnniversaryScheduler.java
@@ -1,0 +1,44 @@
+package com.dolharubang.service.scheduler;
+
+import com.dolharubang.domain.entity.Stone;
+import com.dolharubang.domain.event.AnniversaryEvent;
+import com.dolharubang.repository.StoneRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnniversaryScheduler {
+
+    private final StoneRepository stoneRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 매일 00:00:00에 실행 (cron = "초 분 시 일 월 요일")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void checkAnniversaryDaily() {
+        List<Stone> stones = stoneRepository.findAllByAdoptionDateIsNotNullAndIsDeletedIsNull();
+
+        stones.forEach(stone -> {
+            LocalDate adoptionDate = stone.getAdoptionDate();
+            LocalDate today = LocalDate.now();
+            long daysSinceAdoption = ChronoUnit.DAYS.between(adoptionDate, today);
+
+            eventPublisher.publishEvent(
+                new AnniversaryEvent(
+                    stone.getStoneId(),
+                    stone.getMember().getMemberId(),
+                    today,
+                    daysSinceAdoption
+                )
+            );
+        });
+    }
+
+}

--- a/dolharubang/src/main/java/com/dolharubang/service/scheduler/AnniversaryScheduler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/scheduler/AnniversaryScheduler.java
@@ -8,6 +8,8 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,29 +18,38 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AnniversaryScheduler {
 
+    private static final Logger logger = LoggerFactory.getLogger(AnniversaryScheduler.class);
     private final StoneRepository stoneRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    // 매일 00:00:00에 실행 (cron = "초 분 시 일 월 요일")
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void checkAnniversaryDaily() {
-        List<Stone> stones = stoneRepository.findAllByAdoptionDateIsNotNullAndIsDeletedIsNull();
+        logger.info("기념일 체크 스케줄러 시작");
 
-        stones.forEach(stone -> {
-            LocalDate adoptionDate = stone.getAdoptionDate();
-            LocalDate today = LocalDate.now();
-            long daysSinceAdoption = ChronoUnit.DAYS.between(adoptionDate, today);
+        try {
+            List<Stone> stones = stoneRepository.findAllByAdoptionDateIsNotNullAndDeletedAtIsNull();
+            logger.info("처리할 돌 수: {}", stones.size());
 
-            eventPublisher.publishEvent(
-                new AnniversaryEvent(
-                    stone.getStoneId(),
-                    stone.getMember().getMemberId(),
-                    today,
-                    daysSinceAdoption
-                )
-            );
-        });
+            stones.forEach(stone -> {
+                LocalDate adoptionDate = stone.getAdoptionDate();
+                LocalDate today = LocalDate.now();
+                long daysSinceAdoption = ChronoUnit.DAYS.between(adoptionDate, today) + 1;
+
+                eventPublisher.publishEvent(
+                    new AnniversaryEvent(
+                        stone.getStoneId(),
+                        stone.getMember().getMemberId(),
+                        today,
+                        daysSinceAdoption
+                    )
+                );
+            });
+
+            logger.info("기념일 체크 스케줄러 완료");
+        } catch (Exception e) {
+            logger.error("기념일 체크 중 오류 발생", e);
+            throw e;
+        }
     }
-
 }

--- a/dolharubang/src/main/java/com/dolharubang/service/scheduler/MemberMissionScheduler.java
+++ b/dolharubang/src/main/java/com/dolharubang/service/scheduler/MemberMissionScheduler.java
@@ -1,4 +1,4 @@
-package com.dolharubang.service;
+package com.dolharubang.service.scheduler;
 
 import com.dolharubang.domain.entity.MemberMission;
 import com.dolharubang.repository.MemberMissionRepository;
@@ -21,7 +21,7 @@ public class MemberMissionScheduler {
         this.memberMissionRepository = memberMissionRepository;
     }
 
-    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    @Scheduled(cron = "0 0 4 * * ?") // 매일 4시에 실행
 //    @Scheduled(cron = "0 * * * * ?")  // 매 분 0초에 실행
     @Transactional
     public void resetDailyMissions() {


### PR DESCRIPTION
- 기념일 관련 미션 처리 로직 구현
   - Stone 엔티티 돌 입양 날짜 컬럼 추가 및 관련 부분 수정
   - 기념일 미션 관련 이벤트 작성 및 이벤트 핸들러 구현
   - 매일 자정에 기념일 관련 미션들 처리하는 스케줄러 작성
      - 완료하지 못한 미션 중 가장 하위 기념일수만 체크하는 로직 구현 (ex. 22/50/100 일 중 22일만 우선 체크)
   - MemberMission 엔티티 Stone 엔티티와 연관관계 추가(Null 포함) 및 customName 컬럼 추가